### PR TITLE
feat: 사용자 알러지 관리 기능 구현

### DIFF
--- a/src/main/java/com/gdg_team9/SafePlate/allergy/controller/AllergyController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/controller/AllergyController.java
@@ -1,12 +1,14 @@
 package com.gdg_team9.SafePlate.allergy.controller;
 
+import com.gdg_team9.SafePlate.allergy.dto.AllergyRequest;
 import com.gdg_team9.SafePlate.allergy.dto.AllergyResponse;
 import com.gdg_team9.SafePlate.allergy.service.AllergyService;
 import com.gdg_team9.SafePlate.api.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/allergies")
@@ -18,5 +20,21 @@ public class AllergyController {
     public ApiResponse<AllergyResponse.AllergyListResponse> getAllergies() {
         AllergyResponse.AllergyListResponse response = allergyService.getAllergies();
         return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/my")
+    public ApiResponse<AllergyResponse.AllergyListResponse> getMyAllergies(Principal principal) {
+        String email = principal.getName();
+        AllergyResponse.AllergyListResponse response = allergyService.getMyAllergies(email);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PutMapping("/my")
+    public ApiResponse<Void> updateMyAllergies(
+            @Valid @RequestBody AllergyRequest.UpdateUserAllergyRequest request,
+            Principal principal) {
+        String email = principal.getName();
+        allergyService.updateMyAllergies(email, request.getAllergyIds());
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/allergy/domain/UserAllergy.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/domain/UserAllergy.java
@@ -1,0 +1,33 @@
+package com.gdg_team9.SafePlate.allergy.domain;
+
+import com.gdg_team9.SafePlate.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_allergy")
+@Getter
+@NoArgsConstructor
+public class UserAllergy {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "allergy_id", nullable = false)
+    private Allergy allergy;
+
+    @Builder
+    public UserAllergy(Member member, Allergy allergy) {
+        this.member = member;
+        this.allergy = allergy;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/allergy/dto/AllergyRequest.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/dto/AllergyRequest.java
@@ -1,0 +1,21 @@
+package com.gdg_team9.SafePlate.allergy.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class AllergyRequest {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateUserAllergyRequest {
+        @NotNull(message = "알레르기 ID는 필수 입력 항목입니다.")
+        private List<Long> allergyIds;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/allergy/repository/UserAllergyRepository.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/repository/UserAllergyRepository.java
@@ -1,0 +1,12 @@
+package com.gdg_team9.SafePlate.allergy.repository;
+
+import com.gdg_team9.SafePlate.allergy.domain.UserAllergy;
+import com.gdg_team9.SafePlate.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserAllergyRepository extends JpaRepository<UserAllergy, Long> {
+    List<UserAllergy> findByMember(Member member);
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/gdg_team9/SafePlate/allergy/service/AllergyService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/service/AllergyService.java
@@ -1,8 +1,14 @@
 package com.gdg_team9.SafePlate.allergy.service;
 
 import com.gdg_team9.SafePlate.allergy.domain.Allergy;
+import com.gdg_team9.SafePlate.allergy.domain.UserAllergy;
 import com.gdg_team9.SafePlate.allergy.dto.AllergyResponse;
 import com.gdg_team9.SafePlate.allergy.repository.AllergyRepository;
+import com.gdg_team9.SafePlate.allergy.repository.UserAllergyRepository;
+import com.gdg_team9.SafePlate.api.code.status.ErrorStatus;
+import com.gdg_team9.SafePlate.exception.GeneralException;
+import com.gdg_team9.SafePlate.member.domain.Member;
+import com.gdg_team9.SafePlate.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +20,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AllergyService {
     private final AllergyRepository allergyRepository;
+    private final MemberRepository memberRepository;
+    private final UserAllergyRepository userAllergyRepository;
 
     @Transactional(readOnly = true)
     public AllergyResponse.AllergyListResponse getAllergies(){
@@ -27,5 +35,48 @@ public class AllergyService {
         return AllergyResponse.AllergyListResponse.builder()
                 .allergies(allergyDTOs)
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AllergyResponse.AllergyListResponse getMyAllergies(String email){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._UNAUTHORIZED));
+
+        List<UserAllergy> userAllergies = userAllergyRepository.findByMember(member);
+
+        List<AllergyResponse.AllergyDTO> allergyDTOs = userAllergies.stream()
+                .map(userAllergy -> AllergyResponse.AllergyDTO.builder()
+                .id(userAllergy.getAllergy().getId())
+                        .name(userAllergy.getAllergy().getName())
+                        .build())
+                .collect(Collectors.toList());
+
+        return AllergyResponse.AllergyListResponse.builder()
+                .allergies(allergyDTOs)
+                .build();
+    }
+
+    @Transactional
+    public void updateMyAllergies(String email, List<Long> allergyIds){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._UNAUTHORIZED));
+
+        // 기존 알레르기 정보 삭제
+        userAllergyRepository.deleteByMember(member);
+
+        // 새로운 알레르기 정보 추가
+        List<Allergy> allergies = allergyRepository.findAllById(allergyIds);
+
+        if(allergies.size() != allergyIds.size()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        List<UserAllergy> userAllergies = allergies.stream()
+                .map(allergy -> UserAllergy.builder()
+                        .member(member)
+                        .allergy(allergy)
+                        .build())
+                .collect(Collectors.toList());
+
+        userAllergyRepository.saveAll(userAllergies);
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/config/SecurityConfig.java
+++ b/src/main/java/com/gdg_team9/SafePlate/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                         .usernameParameter("email")
                         .defaultSuccessUrl("/")
                         .loginPage("/auth/login")
+                        .loginProcessingUrl("/auth/login")
                         .permitAll()
                 );
 


### PR DESCRIPTION
## 💫 PR 제목
- [Allergy] 사용자 알러지 관리 기능 구현

---

## 🔧 작업 내용 요약
- GET /allergies/my: 사용자의 알러지 목록 조회
- PUT /allergies/my: 사용자의 알러지 정보 저장/업데이트
- UserAllergy 엔티티 및 Repository 생성 (Member-Allergy 중간 테이블)
- AllergyRequest DTO 생성 (UpdateUserAllergyRequest)
- SecurityConfig에 loginProcessingUrl 설정 추가


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- UserAllergy 엔티티 설계 (Member와 Allergy의 다대다 관계 처리)
- updateMyAllergies 로직 (기존 데이터 삭제 후 새로 저장하는 방식)
- 알러지 ID 유효성 검증 로직
- 현재 session 방식으로 작동

---

## 🔗 관련 이슈
- closes #8

---

## 📝 기타 참고 사항
- 테스트 완료: Postman으로 로그인 → PUT → GET 순서로 검증
- 세션 기반 인증 사용 (Principal에서 email 추출)
- feat/get-allergics 브랜치가 머지되면 자동으로 main에 대한 PR로 변경됩니다 (PR 할때 BASE 변경해둔 상태, feat/get-allergics 브랜치에서 새로 feat/get-allergics 브랜치 만들어서 작업했습니다)
