### PR TITLE
[Member] 사용자 식별 방식 변경

### DIFF
--- a/src/main/java/com/gdg_team9/SafePlate/allergy/controller/AllergyController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/allergy/controller/AllergyController.java
@@ -4,11 +4,11 @@ import com.gdg_team9.SafePlate.allergy.dto.AllergyRequest;
 import com.gdg_team9.SafePlate.allergy.dto.AllergyResponse;
 import com.gdg_team9.SafePlate.allergy.service.AllergyService;
 import com.gdg_team9.SafePlate.api.ApiResponse;
+import com.gdg_team9.SafePlate.member.domain.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @RestController
 @RequestMapping("/allergies")
@@ -23,17 +23,20 @@ public class AllergyController {
     }
 
     @GetMapping("/my")
-    public ApiResponse<AllergyResponse.AllergyListResponse> getMyAllergies(Principal principal) {
-        String email = principal.getName();
+    public ApiResponse<AllergyResponse.AllergyListResponse> getMyAllergies(
+            @AuthenticationPrincipal Member member
+    ) {
+        String email = member.getEmail();
         AllergyResponse.AllergyListResponse response = allergyService.getMyAllergies(email);
         return ApiResponse.onSuccess(response);
     }
 
     @PutMapping("/my")
     public ApiResponse<Void> updateMyAllergies(
-            @Valid @RequestBody AllergyRequest.UpdateUserAllergyRequest request,
-            Principal principal) {
-        String email = principal.getName();
+            @AuthenticationPrincipal Member member,
+            @Valid @RequestBody AllergyRequest.UpdateUserAllergyRequest request
+            ) {
+        String email = member.getEmail();
         allergyService.updateMyAllergies(email, request.getAllergyIds());
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/gdg_team9/SafePlate/member/domain/Member.java
+++ b/src/main/java/com/gdg_team9/SafePlate/member/domain/Member.java
@@ -4,11 +4,16 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Member {
+public class Member implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,5 +31,35 @@ public class Member {
         this.email = email;
         this.password = password;
         this.name = name;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getUsername() {
+        return getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/member/service/CustomUserDetailsService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/member/service/CustomUserDetailsService.java
@@ -19,10 +19,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
-        return User.builder()
-                .username(member.getEmail())
-                .password(member.getPassword())
-                .roles("USER")
-                .build();
+        return member;
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/controller/RestaurantController.java
@@ -1,13 +1,13 @@
 package com.gdg_team9.SafePlate.restaurant.controller;
 
 import com.gdg_team9.SafePlate.api.ApiResponse;
+import com.gdg_team9.SafePlate.member.domain.Member;
 import com.gdg_team9.SafePlate.restaurant.dto.AiClientResponse;
 import com.gdg_team9.SafePlate.restaurant.dto.RestaurantRequest;
 import com.gdg_team9.SafePlate.restaurant.service.RestaurantService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,12 +21,11 @@ public class RestaurantController {
 
     @PostMapping("/search")
     public ApiResponse<AiClientResponse.SearchResponse> searchRestaurant(
-            // TODO: 사용자 데이터 형식 변경 필요
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal Member member,
             @Valid @RequestBody RestaurantRequest.SearchRequest searchRequest
     ) {
         AiClientResponse.SearchResponse searchResponse =
-                restaurantService.searchRestaurant(user.getUsername(), searchRequest);
+                restaurantService.searchRestaurant(member.getUsername(), searchRequest);
         return ApiResponse.onSuccess(searchResponse);
     }
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 사용자 식별 방식 변경

---

## 🔧 작업 내용 요약
- 로그인 시 UserDetails 객체로 Member를 사용하고, 요청이 들어올 때 `@AuthenticationPrincipal Member member`로 사용자 정보를 받도록 함
- 아직 사용자를 한 번 더 확인하는 문제는 수정되지 않은 상태

---

## 📝 기타 참고 사항
- 어제 대면 회의 때 직접 논의한 부분