### PR TITLE
refactor: replace session-based auth with JWT for better cross-origin…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 dependencyManagement {
     imports {

--- a/src/main/java/com/gdg_team9/SafePlate/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gdg_team9/SafePlate/config/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.gdg_team9.SafePlate.config;
+
+import com.gdg_team9.SafePlate.member.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            if (jwtUtil.validateToken(token)) {
+                String email = jwtUtil.getEmailFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/config/JwtUtil.java
+++ b/src/main/java/com/gdg_team9/SafePlate/config/JwtUtil.java
@@ -1,0 +1,54 @@
+package com.gdg_team9.SafePlate.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret,
+                   @Value("${jwt.expiration}") long expiration) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+    }
+
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getEmailFromToken(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/config/SecurityConfig.java
+++ b/src/main/java/com/gdg_team9/SafePlate/config/SecurityConfig.java
@@ -1,26 +1,28 @@
 package com.gdg_team9.SafePlate.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -28,43 +30,21 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .formLogin(form -> form
-                        .usernameParameter("email")
-                        .loginProcessingUrl("/auth/login")
-                        .successHandler((request, response, authentication) -> {
-                            response.setStatus(200);
-                            response.setContentType("application/json;charset=UTF-8");
-
-                            Map<String, String> data = new HashMap<>();
-                            data.put("message", "Login Success");
-
-                            // 직접 생성한 objectMapper 사용
-                            response.getWriter().write(objectMapper.writeValueAsString(data));
-                        })
-                        .failureHandler((request, response, exception) -> {
-                            response.setStatus(401);
-                            response.setContentType("application/json;charset=UTF-8");
-
-                            Map<String, String> data = new HashMap<>();
-                            data.put("message", "Login Failed");
-
-                            response.getWriter().write(objectMapper.writeValueAsString(data));
-                        })
-                        .permitAll()
-                )
-                .logout(logout -> logout
-                        .logoutUrl("/auth/logout")
-                        .logoutSuccessHandler((request, response, authentication) -> {
-                            response.setStatus(200);
-                        })
-                );
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/gdg_team9/SafePlate/member/controller/AuthController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/member/controller/AuthController.java
@@ -2,24 +2,42 @@ package com.gdg_team9.SafePlate.member.controller;
 
 import com.gdg_team9.SafePlate.api.ApiResponse;
 import com.gdg_team9.SafePlate.api.code.status.SuccessStatus;
+import com.gdg_team9.SafePlate.config.JwtUtil;
 import com.gdg_team9.SafePlate.member.dto.MemberRequest;
 import com.gdg_team9.SafePlate.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
     private final MemberService memberService;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/join")
-    public ApiResponse<Void> join(@Valid @RequestBody MemberRequest.JoinRequest request){
+    public ApiResponse<Void> join(@Valid @RequestBody MemberRequest.JoinRequest request) {
         memberService.join(request.getEmail(), request.getPassword(), request.getName());
         return ApiResponse.of(SuccessStatus._CREATED, null);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<Map<String, String>> login(@Valid @RequestBody MemberRequest.LoginRequest request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        );
+
+        String token = jwtUtil.generateToken(request.getEmail());
+        return ApiResponse.of(SuccessStatus._OK, Map.of("token", token));
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/member/dto/MemberRequest.java
+++ b/src/main/java/com/gdg_team9/SafePlate/member/dto/MemberRequest.java
@@ -26,4 +26,17 @@ public class MemberRequest {
         @NotBlank(message = "이름은 필수 입력 항목입니다.")
         private String name;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginRequest {
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        private String password;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.jpa.show-sql=true
 
 # TODO: AI ?? URL ?? ??
 ai-server.url=http://localhost:8080
+
+# JWT Settings
+jwt.secret=${JWT_SECRET:local-dev-secret-key-must-be-32-chars}
+jwt.expiration=${JWT_EXPIRATION:3600000}


### PR DESCRIPTION
… support

## 💫 PR 제목
- [Auth] 세션 기반 인증을 JWT 방식으로 리팩토링


---

## 🔧 작업 내용 요약
- Spring Security의 formLogin + 세션 방식 인증을 JWT 토큰 기반 인증으로 전환
- JwtUtil 클래스 추가 (토큰 생성/검증/파싱)
- JwtAuthenticationFilter 추가 (요청마다 Authorization 헤더에서 토큰 검증)
- SecurityConfig 수정 (SessionCreationPolicy.STATELESS, JWT 필터 등록)
- AuthController에 로그인 시 JWT 토큰 발급 엔드포인트 추가
- MemberRequest.LoginRequest DTO 추가
- JWT secret key를 환경변수(JWT_SECRET)로 관리하도록 설정


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- JwtUtil의 토큰 생성/검증 로직이 적절한지
- SecurityConfig의 필터 체인 구성 및 인가 설정
- 로그인 실패 시 예외 처리 방식 (현재 Spring 기본 예외 처리에 위임)

---

## 🔗 관련 이슈
- closes #14 

---

## 📝 기타 참고 사항
- 배포 시 JWT_SECRET 환경변수 설정 필요 (32자 이상)
- 로컬 개발 시에는 기본값이 적용되므로 별도 설정 불필요
- 토큰 만료 시간은 기본 1시간 (JWT_EXPIRATION 환경변수로 변경 가능)
