### PR TITLE
[Restaurant] 메뉴 검색 시 AI 서버의 이미지 업로드용 presigned url 제공

### DIFF
--- a/src/main/java/com/gdg_team9/SafePlate/file/dto/FileRequest.java
+++ b/src/main/java/com/gdg_team9/SafePlate/file/dto/FileRequest.java
@@ -3,15 +3,13 @@ package com.gdg_team9.SafePlate.file.dto;
 import com.gdg_team9.SafePlate.file.domain.FileStatus;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 public class FileRequest {
 
     @Getter
     @Setter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PresignedUrlRequest {
@@ -30,6 +28,7 @@ public class FileRequest {
 
     @Getter
     @Setter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PatchStatusRequest {

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/controller/RestaurantController.java
@@ -2,8 +2,8 @@ package com.gdg_team9.SafePlate.restaurant.controller;
 
 import com.gdg_team9.SafePlate.api.ApiResponse;
 import com.gdg_team9.SafePlate.member.domain.Member;
-import com.gdg_team9.SafePlate.restaurant.domain.RestaurantSearchResult;
 import com.gdg_team9.SafePlate.restaurant.dto.RestaurantRequest;
+import com.gdg_team9.SafePlate.restaurant.dto.RestaurantResponse;
 import com.gdg_team9.SafePlate.restaurant.service.RestaurantService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +20,11 @@ public class RestaurantController {
     private final RestaurantService restaurantService;
 
     @PostMapping("/search")
-    public ApiResponse<RestaurantSearchResult> searchRestaurant(
+    public ApiResponse<RestaurantResponse.SearchResult> searchRestaurant(
             @AuthenticationPrincipal Member member,
             @Valid @RequestBody RestaurantRequest.SearchRequest searchRequest
     ) {
-        RestaurantSearchResult searchResponse =
+        RestaurantResponse.SearchResult searchResponse =
                 restaurantService.searchRestaurant(member, searchRequest);
         return ApiResponse.onSuccess(searchResponse);
     }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/domain/SearchHistory.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/domain/SearchHistory.java
@@ -1,16 +1,7 @@
 package com.gdg_team9.SafePlate.restaurant.domain;
 
 import com.gdg_team9.SafePlate.member.domain.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -42,6 +33,10 @@ public class SearchHistory {
     private List<Long> imageIds;
 
     @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "result_image_ids", nullable = false, columnDefinition = "json")
+    private List<Long> resultImageIds;
+
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "search_result", nullable = false, columnDefinition = "json")
     private RestaurantSearchResult searchResult;
 
@@ -50,9 +45,10 @@ public class SearchHistory {
     private LocalDateTime createdAt;
 
     @Builder
-    public SearchHistory(Member member, List<Long> imageIds, RestaurantSearchResult searchResult) {
+    public SearchHistory(Member member, List<Long> imageIds, List<Long> resultImageIds, RestaurantSearchResult searchResult) {
         this.member = member;
         this.imageIds = imageIds;
+        this.resultImageIds = resultImageIds;
         this.searchResult = searchResult;
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/AiClientRequest.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/AiClientRequest.java
@@ -1,11 +1,7 @@
 package com.gdg_team9.SafePlate.restaurant.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
@@ -19,7 +15,12 @@ public class AiClientRequest {
     public static class SearchRequest {
         @JsonProperty("image_url")
         private String imageUrl;
+
+        @JsonProperty("presigned_url")
+        private String presignedUrl;
+
         private List<String> avoid;
+
         private String lang;
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/RestaurantResponse.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/RestaurantResponse.java
@@ -1,0 +1,75 @@
+package com.gdg_team9.SafePlate.restaurant.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+public class RestaurantResponse {
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchResult {
+        @JsonProperty("items_extracted")
+        private List<String> itemsExtracted;
+
+        private List<Item> items;
+
+        private Item best;
+
+        @JsonProperty("result_image_urls")
+        private List<String> resultImageUrls;
+
+        @JsonProperty("timings_ms")
+        private Timings timingsMs;
+
+        @Getter
+        @Setter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Item {
+            private String menu;
+
+            @JsonProperty("menu_original")
+            private String menuOriginal;
+
+            private int score;
+
+            private int risk;
+
+            private double confidence;
+
+            @JsonProperty("matched_avoid")
+            private List<String> matchedAvoid;
+
+            @JsonProperty("suspected_ingredients")
+            private List<String> suspectedIngredients;
+
+            private String reason;
+        }
+
+        @Getter
+        @Setter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Timings {
+            @JsonProperty("image_load")
+            private int imageLoad;
+
+            private int extract;
+
+            @JsonProperty("risk_assess")
+            private int riskAssess;
+
+            @JsonProperty("score_policy")
+            private int scorePolicy;
+
+            private int total;
+        }
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/SearchHistoryResponse.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/SearchHistoryResponse.java
@@ -27,6 +27,7 @@ public class SearchHistoryResponse {
         public static class Item {
             private long id;
             private List<String> imageUrls;
+            private List<String> resultImageUrls;
             private RestaurantSearchResult searchResult;
             private LocalDateTime createdAt;
         }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
@@ -4,6 +4,9 @@ import com.gdg_team9.SafePlate.api.code.status.ErrorStatus;
 import com.gdg_team9.SafePlate.avoid.domain.AvoidItem;
 import com.gdg_team9.SafePlate.avoid.repository.AvoidItemRepository;
 import com.gdg_team9.SafePlate.exception.GeneralException;
+import com.gdg_team9.SafePlate.file.domain.FileStatus;
+import com.gdg_team9.SafePlate.file.dto.FileRequest;
+import com.gdg_team9.SafePlate.file.dto.FileResponse;
 import com.gdg_team9.SafePlate.file.service.FileService;
 import com.gdg_team9.SafePlate.member.domain.Member;
 import com.gdg_team9.SafePlate.restaurant.domain.RestaurantSearchResult;
@@ -66,17 +69,32 @@ public class RestaurantService {
         }
 
         // TODO 이미지 여러 개 보낼 수 있도록 수정
+        FileRequest.PresignedUrlRequest presignedUrlRequest =
+                FileRequest.PresignedUrlRequest.builder()
+                        .path("menu_board_response")
+                        .fileType("png")
+                        .build();
+        FileResponse.PresignedUrlResponse preSignedUrl =
+                fileService.getPreSignedUrl(member, presignedUrlRequest);
+
         AiClientRequest.SearchRequest aiSearchRequest = AiClientRequest.SearchRequest.builder()
                 .imageUrl(imageUrls.get(0))
                 .avoid(userAllergies)
+                .presignedUrl(preSignedUrl.getPresignedUrl())
                 .lang(member.getLanguage())
                 .build();
         try {
             RestaurantSearchResult searchResult = aiClient.requestSearch(aiSearchRequest).getBody();
 
+            FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
+                    .fileStatus(FileStatus.UPLOADED)
+                    .build();
+            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
+
             SearchHistory searchHistory = SearchHistory.builder()
                     .member(member)
                     .imageIds(clientSearchRequest.getIds())
+                    .resultImageIds(List.of(preSignedUrl.getFileId()))
                     .searchResult(searchResult)
                     .build();
 
@@ -84,8 +102,18 @@ public class RestaurantService {
             return searchResult;
 
         } catch (feign.RetryableException e) {
+            FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
+                    .fileStatus(FileStatus.ERROR)
+                    .build();
+            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
+
             throw new GeneralException(ErrorStatus.AI_CONNECT_FAIL);
         } catch (feign.FeignException e) {
+            FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
+                    .fileStatus(FileStatus.ERROR)
+                    .build();
+            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
+
             throw new GeneralException(ErrorStatus.AI_SERVER_FAIL);
         }
     }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
@@ -13,6 +13,7 @@ import com.gdg_team9.SafePlate.restaurant.domain.RestaurantSearchResult;
 import com.gdg_team9.SafePlate.restaurant.domain.SearchHistory;
 import com.gdg_team9.SafePlate.restaurant.dto.AiClientRequest;
 import com.gdg_team9.SafePlate.restaurant.dto.RestaurantRequest;
+import com.gdg_team9.SafePlate.restaurant.dto.RestaurantResponse;
 import com.gdg_team9.SafePlate.restaurant.openfeign.AiClient;
 import com.gdg_team9.SafePlate.restaurant.repository.SearchHistoryRepository;
 import com.gdg_team9.SafePlate.team.domain.TeamMember;
@@ -35,7 +36,7 @@ public class RestaurantService {
     private final FileService fileService;
 
     @Transactional
-    public RestaurantSearchResult searchRestaurant(
+    public RestaurantResponse.SearchResult searchRestaurant(
             Member member,
             RestaurantRequest.SearchRequest clientSearchRequest
     ) {
@@ -46,27 +47,7 @@ public class RestaurantService {
             throw new GeneralException(ErrorStatus.FILE_NOT_OWNED);
         }
 
-        List<String> userAllergies;
-
-        Long teamMemberId = clientSearchRequest.getTeamMemberId();
-        if (teamMemberId == null) {
-            userAllergies = avoidItemRepository.findById(member.getId())
-                    .map(AvoidItem::getAvoidItems)
-                    .orElse(List.of());
-        } else {
-            TeamMember teamMember =
-                    teamMemberRepository.findByIdAndMember(teamMemberId, member)
-                            .orElseThrow(() -> new GeneralException(ErrorStatus.TEAM_NOT_FOUND));
-            List<Member> members = teamMember.getTeam().getTeamMembers().stream()
-                    .map(TeamMember::getMember)
-                    .toList();
-
-            userAllergies = avoidItemRepository.findAllByMemberIn(members)
-                    .stream()
-                    .flatMap(avoidItem -> avoidItem.getAvoidItems().stream())
-                    .distinct()
-                    .toList();
-        }
+        List<String> userAllergies = extractUserAllergies(member, clientSearchRequest.getTeamMemberId());
 
         // TODO 이미지 여러 개 보낼 수 있도록 수정
         FileRequest.PresignedUrlRequest presignedUrlRequest =
@@ -89,7 +70,7 @@ public class RestaurantService {
             FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
                     .fileStatus(FileStatus.UPLOADED)
                     .build();
-            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
+            String resultImageUrl = fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
 
             SearchHistory searchHistory = SearchHistory.builder()
                     .member(member)
@@ -99,22 +80,83 @@ public class RestaurantService {
                     .build();
 
             searchHistoryRepository.save(searchHistory);
-            return searchResult;
+
+            // RestaurantSearchResult -> RestaurantResponse.SearchResult 변환
+            return toSearchResultResponse(searchResult, resultImageUrl);
 
         } catch (feign.RetryableException e) {
-            FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
-                    .fileStatus(FileStatus.ERROR)
-                    .build();
-            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
-
+            handleFileError(preSignedUrl.getFileId(), member);
             throw new GeneralException(ErrorStatus.AI_CONNECT_FAIL);
         } catch (feign.FeignException e) {
-            FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
-                    .fileStatus(FileStatus.ERROR)
-                    .build();
-            fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
-
+            handleFileError(preSignedUrl.getFileId(), member);
             throw new GeneralException(ErrorStatus.AI_SERVER_FAIL);
+        }
+    }
+
+    private void handleFileError(Long fileId, Member member) {
+        FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
+                .fileStatus(FileStatus.ERROR)
+                .build();
+        fileService.patchFileStatus(member, fileId, statusRequest);
+    }
+
+    private RestaurantResponse.SearchResult.Item toItemResponse(RestaurantSearchResult.Item item) {
+        return RestaurantResponse.SearchResult.Item.builder()
+                .menu(item.getMenu())
+                .menuOriginal(item.getMenuOriginal())
+                .score(item.getScore())
+                .risk(item.getRisk())
+                .confidence(item.getConfidence())
+                .matchedAvoid(item.getMatchedAvoid())
+                .suspectedIngredients(item.getSuspectedIngredients())
+                .reason(item.getReason())
+                .build();
+    }
+
+    private RestaurantResponse.SearchResult toSearchResultResponse(
+            RestaurantSearchResult searchResult,
+            String resultImageUrl
+    ) {
+        return RestaurantResponse.SearchResult.builder()
+                .itemsExtracted(searchResult.getItemsExtracted())
+                .items(searchResult.getItems().stream()
+                        .map(this::toItemResponse)
+                        .toList()
+                )
+                .best(toItemResponse(searchResult.getBest()))
+                .resultImageUrls(List.of(resultImageUrl))
+                .timingsMs(toTimingsResponse(searchResult.getTimingsMs()))
+                .build();
+    }
+
+    private RestaurantResponse.SearchResult.Timings toTimingsResponse(RestaurantSearchResult.Timings timings) {
+        return RestaurantResponse.SearchResult.Timings.builder()
+                .imageLoad(timings.getImageLoad())
+                .extract(timings.getExtract())
+                .riskAssess(timings.getRiskAssess())
+                .scorePolicy(timings.getScorePolicy())
+                .total(timings.getTotal())
+                .build();
+    }
+
+    private List<String> extractUserAllergies(Member member, Long teamMemberId) {
+        if (teamMemberId == null) {
+            return avoidItemRepository.findById(member.getId())
+                    .map(AvoidItem::getAvoidItems)
+                    .orElse(List.of());
+        } else {
+            TeamMember teamMember =
+                    teamMemberRepository.findByIdAndMember(teamMemberId, member)
+                            .orElseThrow(() -> new GeneralException(ErrorStatus.TEAM_NOT_FOUND));
+            List<Member> members = teamMember.getTeam().getTeamMembers().stream()
+                    .map(TeamMember::getMember)
+                    .toList();
+
+            return avoidItemRepository.findAllByMemberIn(members)
+                    .stream()
+                    .flatMap(avoidItem -> avoidItem.getAvoidItems().stream())
+                    .distinct()
+                    .toList();
         }
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/service/SearchHistoryService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/service/SearchHistoryService.java
@@ -1,8 +1,8 @@
 package com.gdg_team9.SafePlate.restaurant.service;
 
 import com.gdg_team9.SafePlate.api.code.status.ErrorStatus;
-import com.gdg_team9.SafePlate.file.service.FileService;
 import com.gdg_team9.SafePlate.exception.GeneralException;
+import com.gdg_team9.SafePlate.file.service.FileService;
 import com.gdg_team9.SafePlate.member.domain.Member;
 import com.gdg_team9.SafePlate.restaurant.domain.SearchHistory;
 import com.gdg_team9.SafePlate.restaurant.dto.SearchHistoryResponse;
@@ -62,6 +62,7 @@ public class SearchHistoryService {
                 // 추후 친구 기능 추가 시 다른 친구가 올린 이미지 확인이 필요하기 때문
                 // 검색 기록을 저장할 때 소유자가 맞는지 확인함
                 .imageUrls(fileService.getFileUrlsByIds(searchHistory.getImageIds()))
+                .resultImageUrls(fileService.getFileUrlsByIds(searchHistory.getResultImageIds()))
                 .searchResult(searchHistory.getSearchResult())
                 .createdAt(searchHistory.getCreatedAt())
                 .build();

--- a/src/main/resources/db/changelog/changes/007-add-result-image-ids-column.yaml
+++ b/src/main/resources/db/changelog/changes/007-add-result-image-ids-column.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 007-add-result-image-ids-column
+      author: gdg_team9
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - not:
+            - columnExists:
+                tableName: search_history
+                columnName: result_image_ids
+      changes:
+        - addColumn:
+            tableName: search_history
+            columns:
+              - column:
+                  name: result_image_ids
+                  type: json
+                  defaultValueComputed: (JSON_ARRAY())
+                  constraints:
+                    nullable: false


### PR DESCRIPTION
## 💫 PR 제목
- [Restaurant] 메뉴 검색 시 AI 서버의 검색 결과 이미지 저장

---

## 🔧 작업 내용 요약
- AI 서버가 검색 결과 이미지를 저장할 수 있도록, 검색 요청에 presigned url 포함
- AI 서버가 저장한 이미지를 검색 기록에 저장

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 혹시 result image 처리가 누락된 곳이 있는지

---

## 🔗 관련 이슈
- closes #34 

---

## 📝 기타 참고 사항
- 현재 AI 서버가 업로드하는 이미지의 format이 png 파일이라는 점이 가정되어 있음
  - 파일 format 확인 후 변경 필요
- 메뉴 검색 결과 및 검색 기록 조회 API의 response body 변경
  - 다음 항목 추가
    ```json
    "result_image_urls": [
        "https://safeplate26.s3.ap-northeast-2.amazonaws.com/menu_board_response/af20a66d-3dad-4d07-bb0d-470e65f5bb2b.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260318T175918Z&X-Amz-SignedHeaders=host&X-Amz-Credential=AKIA3OOT75TTECGFGENJ%2F20260318%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Expires=600&X-Amz-Signature=97dbe1c37855c5d376dc1b546ba45977a39d0c1fa9a1ab962fb03da751fb88ab"
    ],
    ```
  - 항목 추가만 존재하므로, breaking change는 아님(기존 response body로 가정해도 코드가 동작함)