### PR TITLE
[Avoid] 기피 식재료 preset 구현

### DIFF
--- a/src/main/java/com/gdg_team9/SafePlate/api/code/status/ErrorStatus.java
+++ b/src/main/java/com/gdg_team9/SafePlate/api/code/status/ErrorStatus.java
@@ -31,6 +31,8 @@ public enum ErrorStatus implements BaseErrorCode {
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "GROUP4004", "그룹을 찾을 수 없습니다."),
 
     HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "HISTORY4004", "검색 기록을 찾을 수 없습니다."),
+
+    PRESET_NOT_FOUND(HttpStatus.NOT_FOUND, "PRESET4004", "프리셋을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/controller/AvoidPresetController.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/controller/AvoidPresetController.java
@@ -1,0 +1,41 @@
+package com.gdg_team9.SafePlate.avoid.controller;
+
+import com.gdg_team9.SafePlate.api.ApiResponse;
+import com.gdg_team9.SafePlate.avoid.dto.AvoidPresetResponse;
+import com.gdg_team9.SafePlate.avoid.service.AvoidPresetService;
+import com.gdg_team9.SafePlate.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/avoid-presets")
+@RequiredArgsConstructor
+public class AvoidPresetController {
+
+    private final AvoidPresetService avoidPresetService;
+
+    /**
+     * 모든 Preset 조회 (사용자 언어로 번역)
+     */
+    @GetMapping
+    public ApiResponse<AvoidPresetResponse.PresetListResponse> getAllPresets(
+            @AuthenticationPrincipal Member member
+    ) {
+        return ApiResponse.onSuccess(avoidPresetService.getAllPresets(member.getLanguage()));
+    }
+
+    /**
+     * 특정 Preset 상세 조회
+     */
+    @GetMapping("/{presetId}")
+    public ApiResponse<AvoidPresetResponse.PresetInfoResponse> getPresetDetail(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long presetId
+    ) {
+        return ApiResponse.onSuccess(avoidPresetService.getPresetDetail(presetId, member.getLanguage()));
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPreset.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPreset.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -28,7 +27,6 @@ public class AvoidPreset {
      * preset 이름(관리자 확인용 및 fallback값)
      */
     @Column(name = "preset_name", nullable = false, length = 100)
-    @Setter
     private String presetName;
 
     @OneToMany(mappedBy = "avoidPreset", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPreset.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPreset.java
@@ -1,0 +1,52 @@
+package com.gdg_team9.SafePlate.avoid.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "avoid_preset")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+public class AvoidPreset {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /**
+     * preset 이름(관리자 확인용 및 fallback값)
+     */
+    @Column(name = "preset_name", nullable = false, length = 100)
+    @Setter
+    private String presetName;
+
+    @OneToMany(mappedBy = "avoidPreset", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AvoidPresetTranslation> translations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "avoidPreset", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AvoidPresetItemTranslation> itemTranslations = new ArrayList<>();
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public AvoidPreset(String presetName) {
+        this.presetName = presetName;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPresetItemTranslation.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPresetItemTranslation.java
@@ -1,0 +1,46 @@
+package com.gdg_team9.SafePlate.avoid.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "avoid_preset_item_translation",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_preset_item_language_order",
+                        columnNames = {"preset_id", "language", "item_order"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor
+public class AvoidPresetItemTranslation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "preset_id", nullable = false)
+    private AvoidPreset avoidPreset;
+
+    @Column(name = "language", nullable = false, length = 2)
+    private String language;
+
+    @Column(name = "item_name", nullable = false, length = 100)
+    private String itemName;
+
+    @Column(name = "item_order", nullable = false)
+    private Integer itemOrder;
+
+    @Builder
+    public AvoidPresetItemTranslation(AvoidPreset avoidPreset, String language, String itemName, Integer itemOrder) {
+        this.avoidPreset = avoidPreset;
+        this.language = language;
+        this.itemName = itemName;
+        this.itemOrder = itemOrder;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPresetTranslation.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/domain/AvoidPresetTranslation.java
@@ -1,0 +1,42 @@
+package com.gdg_team9.SafePlate.avoid.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "avoid_preset_translation",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_preset_language",
+                        columnNames = {"preset_id", "language"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor
+public class AvoidPresetTranslation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "preset_id", nullable = false)
+    private AvoidPreset avoidPreset;
+
+    @Column(name = "language", nullable = false, length = 2)
+    private String language;
+
+    @Column(name = "translated_name", nullable = false, length = 100)
+    private String translatedName;
+
+    @Builder
+    public AvoidPresetTranslation(AvoidPreset avoidPreset, String language, String translatedName) {
+        this.avoidPreset = avoidPreset;
+        this.language = language;
+        this.translatedName = translatedName;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/dto/AvoidPresetResponse.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/dto/AvoidPresetResponse.java
@@ -1,0 +1,31 @@
+package com.gdg_team9.SafePlate.avoid.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AvoidPresetResponse {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PresetInfoResponse {
+        private Long presetId;
+        private String presetName;
+        private List<String> items;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PresetListResponse {
+        private List<PresetInfoResponse> presets;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetItemTranslationRepository.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetItemTranslationRepository.java
@@ -1,0 +1,14 @@
+package com.gdg_team9.SafePlate.avoid.repository;
+
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPresetItemTranslation;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AvoidPresetItemTranslationRepository extends JpaRepository<AvoidPresetItemTranslation, Long> {
+    @EntityGraph(attributePaths = {"avoidPreset"})
+    List<AvoidPresetItemTranslation> findAllByLanguageOrderByItemOrder(String language);
+
+    List<AvoidPresetItemTranslation> findByAvoidPresetIdAndLanguageOrderByItemOrder(Long presetId, String language);
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetRepository.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetRepository.java
@@ -1,0 +1,7 @@
+package com.gdg_team9.SafePlate.avoid.repository;
+
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPreset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AvoidPresetRepository extends JpaRepository<AvoidPreset, Long> {
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetTranslationRepository.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/repository/AvoidPresetTranslationRepository.java
@@ -1,0 +1,15 @@
+package com.gdg_team9.SafePlate.avoid.repository;
+
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPresetTranslation;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AvoidPresetTranslationRepository extends JpaRepository<AvoidPresetTranslation, Long> {
+    @EntityGraph(attributePaths = {"avoidPreset"})
+    List<AvoidPresetTranslation> findAllByLanguage(String language);
+
+    Optional<AvoidPresetTranslation> findByAvoidPresetIdAndLanguage(Long presetId, String language);
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidPresetService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidPresetService.java
@@ -1,0 +1,99 @@
+package com.gdg_team9.SafePlate.avoid.service;
+
+import com.gdg_team9.SafePlate.api.code.status.ErrorStatus;
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPreset;
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPresetItemTranslation;
+import com.gdg_team9.SafePlate.avoid.domain.AvoidPresetTranslation;
+import com.gdg_team9.SafePlate.avoid.dto.AvoidPresetResponse;
+import com.gdg_team9.SafePlate.avoid.repository.AvoidPresetItemTranslationRepository;
+import com.gdg_team9.SafePlate.avoid.repository.AvoidPresetRepository;
+import com.gdg_team9.SafePlate.avoid.repository.AvoidPresetTranslationRepository;
+import com.gdg_team9.SafePlate.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AvoidPresetService {
+
+    private final AvoidPresetRepository avoidPresetRepository;
+    private final AvoidPresetTranslationRepository avoidPresetTranslationRepository;
+    private final AvoidPresetItemTranslationRepository avoidPresetItemTranslationRepository;
+
+    /**
+     * 모든 Preset 조회 (사용자 언어로 번역된 이름과 항목 반환)
+     */
+    public AvoidPresetResponse.PresetListResponse getAllPresets(String userLanguage) {
+        List<AvoidPresetItemTranslation> itemTranslations =
+                avoidPresetItemTranslationRepository.findAllByLanguageOrderByItemOrder(userLanguage);
+        List<AvoidPresetTranslation> presetTranslations =
+                avoidPresetTranslationRepository.findAllByLanguage(userLanguage);
+
+        Map<Long, List<String>> itemsPerPresetId = itemTranslations.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                item -> item.getAvoidPreset().getId(),
+                                Collectors.mapping(
+                                        AvoidPresetItemTranslation::getItemName,
+                                        Collectors.toList()
+                                )
+                        )
+                );
+
+
+        List<AvoidPresetResponse.PresetInfoResponse> presetInfos = presetTranslations.stream()
+                .map(translation -> AvoidPresetResponse.PresetInfoResponse.builder()
+                        .presetId(translation.getAvoidPreset().getId())
+                        .presetName(translation.getTranslatedName())
+                        .items(itemsPerPresetId.getOrDefault(translation.getAvoidPreset().getId(), List.of()))
+                        .createdAt(translation.getAvoidPreset().getCreatedAt())
+                        .updatedAt(translation.getAvoidPreset().getUpdatedAt())
+                        .build()
+                )
+                .toList();
+
+        return AvoidPresetResponse.PresetListResponse.builder()
+                .presets(presetInfos)
+                .build();
+    }
+
+    /**
+     * 특정 Preset 상세 조회 (사용자 언어로 번역된 이름과 항목 반환)
+     */
+    public AvoidPresetResponse.PresetInfoResponse getPresetDetail(Long presetId, String userLanguage) {
+        AvoidPreset preset = avoidPresetRepository.findById(presetId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PRESET_NOT_FOUND));
+
+        String displayName = getTranslatedPresetName(preset, userLanguage);
+
+        List<String> items = avoidPresetItemTranslationRepository
+                .findByAvoidPresetIdAndLanguageOrderByItemOrder(preset.getId(), userLanguage)
+                .stream()
+                .map(AvoidPresetItemTranslation::getItemName)
+                .collect(Collectors.toList());
+
+        return AvoidPresetResponse.PresetInfoResponse.builder()
+                .presetId(preset.getId())
+                .presetName(displayName)
+                .items(items)
+                .createdAt(preset.getCreatedAt())
+                .updatedAt(preset.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * Preset 이름의 번역된 버전 조회 (없으면 원본 반환)
+     */
+    private String getTranslatedPresetName(AvoidPreset preset, String language) {
+        return avoidPresetTranslationRepository
+                .findByAvoidPresetIdAndLanguage(preset.getId(), language)
+                .map(AvoidPresetTranslation::getTranslatedName)
+                .orElse(preset.getPresetName());
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidPresetService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidPresetService.java
@@ -30,32 +30,27 @@ public class AvoidPresetService {
      * 모든 Preset 조회 (사용자 언어로 번역된 이름과 항목 반환)
      */
     public AvoidPresetResponse.PresetListResponse getAllPresets(String userLanguage) {
-        List<AvoidPresetItemTranslation> itemTranslations =
-                avoidPresetItemTranslationRepository.findAllByLanguageOrderByItemOrder(userLanguage);
-        List<AvoidPresetTranslation> presetTranslations =
-                avoidPresetTranslationRepository.findAllByLanguage(userLanguage);
+        List<AvoidPreset> allPresets = avoidPresetRepository.findAll();
 
-        Map<Long, List<String>> itemsPerPresetId = itemTranslations.stream()
-                .collect(
-                        Collectors.groupingBy(
-                                item -> item.getAvoidPreset().getId(),
-                                Collectors.mapping(
-                                        AvoidPresetItemTranslation::getItemName,
-                                        Collectors.toList()
-                                )
-                        )
-                );
+        Map<Long, String> translatedNames = avoidPresetTranslationRepository.findAllByLanguage(userLanguage)
+                .stream()
+                .collect(Collectors.toMap(t -> t.getAvoidPreset().getId(), AvoidPresetTranslation::getTranslatedName));
 
+        Map<Long, List<String>> itemsPerPreset = avoidPresetItemTranslationRepository.findAllByLanguageOrderByItemOrder(userLanguage)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        item -> item.getAvoidPreset().getId(),
+                        Collectors.mapping(AvoidPresetItemTranslation::getItemName, Collectors.toList())
+                ));
 
-        List<AvoidPresetResponse.PresetInfoResponse> presetInfos = presetTranslations.stream()
-                .map(translation -> AvoidPresetResponse.PresetInfoResponse.builder()
-                        .presetId(translation.getAvoidPreset().getId())
-                        .presetName(translation.getTranslatedName())
-                        .items(itemsPerPresetId.getOrDefault(translation.getAvoidPreset().getId(), List.of()))
-                        .createdAt(translation.getAvoidPreset().getCreatedAt())
-                        .updatedAt(translation.getAvoidPreset().getUpdatedAt())
-                        .build()
-                )
+        List<AvoidPresetResponse.PresetInfoResponse> presetInfos = allPresets.stream()
+                .map(preset -> AvoidPresetResponse.PresetInfoResponse.builder()
+                        .presetId(preset.getId())
+                        .presetName(translatedNames.getOrDefault(preset.getId(), preset.getPresetName()))
+                        .items(itemsPerPreset.getOrDefault(preset.getId(), List.of()))
+                        .createdAt(preset.getCreatedAt())
+                        .updatedAt(preset.getUpdatedAt())
+                        .build())
                 .toList();
 
         return AvoidPresetResponse.PresetListResponse.builder()

--- a/src/main/resources/db/changelog/changes/008-avoid-preset.yaml
+++ b/src/main/resources/db/changelog/changes/008-avoid-preset.yaml
@@ -112,3 +112,195 @@ databaseChangeLog:
             constraintName: FK_AVOID_PRESET_TRANSLATION_ON_PRESET
             referencedColumnNames: id
             referencedTableName: avoid_preset
+
+  # Preset 1: Vegan (비건)
+  - changeSet:
+      id: 008-avoid-preset-insert-vegan
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('VEGAN', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'ko', '비건'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'en', 'Vegan'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'zh', '纯素食');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'ko', '동물성 식품', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'en', 'Animal products', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'zh', '动物产品', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'ko', '동물 유래 식품 첨가물', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'en', 'Animal-derived additives', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'zh', '动物源添加剂', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'ko', '동물성 성분', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'en', 'Animal ingredients', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'VEGAN'), 'zh', '动物成分', 3);
+
+  # Preset 2: Islam (이슬람)
+  - changeSet:
+      id: 008-avoid-preset-insert-islam
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('ISLAM', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'ko', '이슬람'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'en', 'Islam (Halal)'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'zh', '伊斯兰教');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'ko', '돼지고기', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'en', 'Pork', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'zh', '猪肉', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'ko', '피', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'en', 'Blood', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'zh', '血液', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'ko', '알코올', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'en', 'Alcohol', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'ISLAM'), 'zh', '酒精', 3);
+
+  # Preset 3: Judaism (유대교)
+  - changeSet:
+      id: 008-avoid-preset-insert-judaism
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('JUDAISM', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'ko', '유대교'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'en', 'Judaism (Kosher)'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'zh', '犹太教');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'ko', '돼지고기', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'en', 'Pork', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'zh', '猪肉', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'ko', '비늘 없는 해산물', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'en', 'Shellfish and scaleless seafood', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'zh', '无鳞海鲜', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'ko', '피', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'en', 'Blood', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'zh', '血液', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'ko', '육류와 유제품 혼합', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'en', 'Mixing meat and dairy', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JUDAISM'), 'zh', '肉类和乳制品混合', 4);
+
+  # Preset 4: Buddhism (불교)
+  - changeSet:
+      id: 008-avoid-preset-insert-buddhism
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('BUDDHISM', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'ko', '불교'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'en', 'Buddhism'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'zh', '佛教');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'ko', '동물성 식품', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'en', 'Animal products', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'zh', '动物产品', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'ko', '동물 유래 식품 첨가물', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'en', 'Animal-derived additives', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'zh', '动物源添加剂', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'ko', '동물성 성분', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'en', 'Animal ingredients', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'BUDDHISM'), 'zh', '动物成分', 3);
+
+  # Preset 5: Jainism (자이나교)
+  - changeSet:
+      id: 008-avoid-preset-insert-jainism
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('JAINISM', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '자이나교'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Jainism'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '耆那教');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '육류', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Meat', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '肉类', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '생선', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Fish', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '鱼', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '달걀', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Eggs', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '鸡蛋', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '뿌리채소', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Root vegetables', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '根菜类', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '꿀', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Honey', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '蜂蜜', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'ko', '발효식품', 6),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'en', 'Fermented foods', 6),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'JAINISM'), 'zh', '发酵食品', 6);
+
+  # Preset 6: Pregnancy (임산부)
+  - changeSet:
+      id: 008-avoid-preset-insert-pregnancy
+      author: gdg_team9
+      changes:
+        - sql:
+            sql: |
+              INSERT INTO avoid_preset (preset_name, created_at, updated_at) VALUES ('PREGNANCY', NOW(), NOW());
+              
+              INSERT INTO avoid_preset_translation (preset_id, language, translated_name)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '임산부'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Pregnancy'),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '怀孕');
+
+              INSERT INTO avoid_preset_item_translation (preset_id, language, item_name, item_order)
+              VALUES
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '날고기', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Raw meat', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '生肉', 1),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '사전 조리된 샐러드', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Pre-made salads', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '预制沙拉', 2),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '익히지 않은 새싹', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Raw sprouts', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '生芽菜', 3),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '열을 가하지 않은 치즈', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Unpasteurized cheese', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '未巴氏消毒的奶酪', 4),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '날계란', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Raw eggs', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '生鸡蛋', 5),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '반숙 계란', 6),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Soft-boiled eggs', 6),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '半熟鸡蛋', 6),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '익히지 않은 생선', 7),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Raw fish (sushi, sashimi, ceviche)', 7),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '生鱼', 7),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '수은 함량이 높은 생선', 8),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'High-mercury fish', 8),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '高汞鱼', 8),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'ko', '익히지 않은 밀', 9),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'en', 'Raw grain', 9),
+              ((SELECT id FROM avoid_preset WHERE preset_name = 'PREGNANCY'), 'zh', '生谷物', 9);

--- a/src/main/resources/db/changelog/changes/008-avoid-preset.yaml
+++ b/src/main/resources/db/changelog/changes/008-avoid-preset.yaml
@@ -1,0 +1,114 @@
+databaseChangeLog:
+  - changeSet:
+      id: 008-avoid-preset
+      author: gdg_team9
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - not:
+            - tableExists:
+                tableName: avoid_preset
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_avoid_preset
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: preset_name
+                  type: VARCHAR(100)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  constraints:
+                    nullable: false
+                  name: updated_at
+                  type: DATETIME
+            tableName: avoid_preset
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_avoid_preset_item_translation
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: preset_id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: language
+                  type: VARCHAR(2)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: item_name
+                  type: VARCHAR(100)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: item_order
+                  type: INT
+            tableName: avoid_preset_item_translation
+        - addUniqueConstraint:
+            columnNames: preset_id, language, item_order
+            constraintName: uk_preset_item_language_order
+            tableName: avoid_preset_item_translation
+        - addForeignKeyConstraint:
+            baseColumnNames: preset_id
+            baseTableName: avoid_preset_item_translation
+            constraintName: FK_AVOID_PRESET_ITEM_TRANSLATION_ON_PRESET
+            referencedColumnNames: id
+            referencedTableName: avoid_preset
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_avoid_preset_translation
+                  name: id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: preset_id
+                  type: BIGINT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: language
+                  type: VARCHAR(2)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: translated_name
+                  type: VARCHAR(100)
+            tableName: avoid_preset_translation
+        - addUniqueConstraint:
+            columnNames: preset_id, language
+            constraintName: uk_preset_language
+            tableName: avoid_preset_translation
+        - addForeignKeyConstraint:
+            baseColumnNames: preset_id
+            baseTableName: avoid_preset_translation
+            constraintName: FK_AVOID_PRESET_TRANSLATION_ON_PRESET
+            referencedColumnNames: id
+            referencedTableName: avoid_preset


### PR DESCRIPTION
## 💫 PR 제목
- [Avoid] 기피 식재료 preset 구현

---

## 🔧 작업 내용 요약
- 기피 식재료 DB 저장
- 기피 식재료 preset 조회 구현
- 비건, 임산부 등 6가지 항목에 대해, 한국어, 영어, 중국어 3개 언어로 초기 데이터 DB 저장

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- **초기 preset이 적절한지**
  <details>
    <summary>기준으로 삼은 기피 식재료 정보</summary>
    
    - 비건
      - 동물성 식품
      - 동물 유래 식품 첨가물
      - 동물성 성분

    - 이슬람
      - 돼지고기
      - 피
      - 알코올

    - 유대교
      - 돼지고기
      - 비늘 없는 해산물
      - 피
      - 육류와 유제품 혼합

    - 불교
      - 동물성 식품
      - 동물 유래 식품 첨가물
      - 동물성 성분

    - 자이나교
      - 육류
      - 생선
      - 달걀
      - 뿌리채소
      - 꿀
      - 발효식품

    - 임산부
      - 날고기 (익히지 않은 고기)
      - 사전 조리된 샐러드
      - 익히지 않은 새싹
      - 퀘소 프레스코 치즈(queso fresco-type cheese)
      - 열을 가하지 않은 치즈
      - 날계란
      - 반숙 계란
      - 익히지 않은 생선(사시미, 스시, 세비체 등)
      - 수은 함량이 높은 생선
      - 익히지 않은 밀
    </details>

- DB 설계가 적절한지

---

## 🔗 관련 이슈
- closes #36 

---

## 📝 기타 참고 사항
- **liquibase changelog 순서 상 #35 먼저 merge 필요**
  - 이 PR을 먼저 merge 시 에러 발생