### PR TITLE
[Restaurant] 부하 테스트 구현 및 AI 서버 호출 부분을 Transaction에서 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.liquibase.gradle' version '3.1.0'
     id "org.springdoc.openapi-gradle-plugin" version "1.9.0"
+    id 'io.gatling.gradle' version '3.15.0'
 }
 ext {
     springCloudVersion = "2025.1.0"

--- a/src/gatling/java/com/gdg_team9/SafePlate/restaurant/RestaurantSearchSimulation.java
+++ b/src/gatling/java/com/gdg_team9/SafePlate/restaurant/RestaurantSearchSimulation.java
@@ -1,0 +1,80 @@
+package com.gdg_team9.SafePlate.restaurant;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+import io.gatling.javaapi.core.Simulation;
+import io.gatling.javaapi.http.HttpProtocolBuilder;
+
+import java.time.Duration;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
+
+/**
+ * 부하 테스트: 식당 검색 API (/restaurant/search)
+ * <p>
+ * 시나리오: 200개의 검색 요청을 동시에 보내고 응답 시간과 성공 여부를 측정
+ * <p>
+ * 실행 방법: ./gradlew gatlingRun
+ * --simulation=com.gdg_team9.SafePlate.restaurant.RestaurantSearchSimulation
+ * <p>
+ * 실행 전 검색 요청 바디가 적절한지 확인 필요
+ */
+public class RestaurantSearchSimulation extends Simulation {
+
+    // ============ HTTP 설정 ============
+    private final HttpProtocolBuilder httpProtocol = http
+            .baseUrl("http://localhost:8080")
+            .acceptHeader("application/json")
+            .contentTypeHeader("application/json")
+            .userAgentHeader("Gatling/RestaurantSearch");
+
+    // ============ 검색 요청 바디 ============
+    // 사용 전 검색 요청 바디가 적절한지 확인
+    private final String loginRequestBody = """
+            {
+                "email": "a@b.com",
+                "password": "12345678"
+            }
+            """;
+    private final String searchRequestBody = """
+            {
+                "ids": [5],
+                "menuLang": "ko"
+            }
+            """;
+
+    // ============ 시나리오 정의 ============
+    private final ScenarioBuilder searchScenario = scenario("Restaurant Search Load Test")
+            .exec(
+                    http("POST /login")
+                            .post("/auth/login")
+                            .body(StringBody(loginRequestBody))
+                            .requestTimeout(Duration.ofSeconds(10))
+                            .check(status().is(200))
+                            .check(jsonPath("$.isSuccess").is("true"))
+                            .check(jsonPath("$.result.token").exists())
+                            .check(jsonPath("$.result.token").saveAs("authToken"))
+            )
+            .pause(Duration.ofSeconds(3))  // 로그인 후 3초 대기
+            .exec(
+                    http("POST /restaurant/search")
+                            .post("/restaurant/search")
+                            .header("Authorization", "Bearer #{authToken}")
+                            .body(StringBody(searchRequestBody))
+                            .requestTimeout(Duration.ofSeconds(140))
+                            .check(status().is(200))
+                            .check(responseTimeInMillis().saveAs("responseTime"))
+            )
+            .pause(Duration.ofMillis(500));  // 요청 간 500ms 대기
+
+    // ============ 부하 테스트 설정 ============
+    {
+        setUp(
+                searchScenario.injectOpen(
+                                atOnceUsers(200) // 요청 200개를 한 번에 보냄
+                        )
+                        .protocols(httpProtocol)
+        ).maxDuration(Duration.ofSeconds(150));  // 최대 테스트 시간 150초
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidItemService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/avoid/service/AvoidItemService.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AvoidItemService {
 
@@ -49,6 +48,7 @@ public class AvoidItemService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public AvoidItemResponse.MyAvoidResponse getMyAvoid(Member member) {
         List<String> avoidItem = avoidItemRepository.findById(member.getId())
                 .map(AvoidItem::getAvoidItems)

--- a/src/main/java/com/gdg_team9/SafePlate/config/FeignConfig.java
+++ b/src/main/java/com/gdg_team9/SafePlate/config/FeignConfig.java
@@ -1,0 +1,32 @@
+package com.gdg_team9.SafePlate.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
+import org.springframework.cloud.openfeign.support.HttpMessageConverterCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+
+@Configuration
+public class FeignConfig {
+    /**
+     * 동시에 여러 스레드에서 Feign client(AI서버 호출 로직)를 사용할 때,
+     * HttpMessageConverter가 초기화되지 않아 발생하는 문제를 방지하기 위한 Bean 정의
+     * <p>
+     * 자세한 내용은 다음 Issue 참고:
+     * <a href="https://github.com/spring-cloud/spring-cloud-openfeign/issues/1307">
+     * https://github.com/spring-cloud/spring-cloud-openfeign/issues/1307
+     * </a>
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public FeignHttpMessageConverters feignHttpMessageConverters(
+            ObjectProvider<HttpMessageConverter<?>> messageConverters,
+            ObjectProvider<HttpMessageConverterCustomizer> customizers) {
+        var feignHttpMessageConverters = new FeignHttpMessageConverters(messageConverters, customizers);
+        // init converters
+        feignHttpMessageConverters.getConverters();
+        return feignHttpMessageConverters;
+    }
+}

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/AiClientRequest.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/dto/AiClientRequest.java
@@ -1,6 +1,7 @@
 package com.gdg_team9.SafePlate.restaurant.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gdg_team9.SafePlate.file.dto.FileResponse;
 import lombok.*;
 
 import java.util.List;
@@ -25,5 +26,16 @@ public class AiClientRequest {
         private List<String> avoid;
 
         private String lang;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchPreparedData {
+        private List<String> imageUrls;
+        private List<String> userAllergies;
+        private FileResponse.PresignedUrlResponse preSignedUrl;
     }
 }

--- a/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
+++ b/src/main/java/com/gdg_team9/SafePlate/restaurant/service/RestaurantService.java
@@ -21,13 +21,12 @@ import com.gdg_team9.SafePlate.team.repository.TeamMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Slf4j
 public class RestaurantService {
     private final AiClient aiClient;
@@ -37,34 +36,44 @@ public class RestaurantService {
 
     private final FileService fileService;
 
-    @Transactional
+    private final TransactionTemplate transactionTemplate;
+
     public RestaurantResponse.SearchResult searchRestaurant(
             Member member,
             RestaurantRequest.SearchRequest clientSearchRequest
     ) {
-        // 검색 전에는 업로드한 사람 본인의 이미지가 맞는지 확인 시행
-        List<String> imageUrls = fileService.getFileUrlsByMemberAndIds(member, clientSearchRequest.getIds());
+        AiClientRequest.SearchPreparedData result = transactionTemplate.execute(status -> {
+            // 검색 전에는 업로드한 사람 본인의 이미지가 맞는지 확인 시행
+            List<String> imageUrls = fileService.getFileUrlsByMemberAndIds(member, clientSearchRequest.getIds());
 
-        if (clientSearchRequest.getIds().size() != imageUrls.size()) {
-            throw new GeneralException(ErrorStatus.FILE_NOT_OWNED);
-        }
+            if (clientSearchRequest.getIds().size() != imageUrls.size()) {
+                throw new GeneralException(ErrorStatus.FILE_NOT_OWNED);
+            }
 
-        List<String> userAllergies = extractUserAllergies(member, clientSearchRequest.getTeamMemberId());
+            List<String> userAllergies = extractUserAllergies(member, clientSearchRequest.getTeamMemberId());
 
-        // TODO 이미지 여러 개 보낼 수 있도록 수정
-        FileRequest.PresignedUrlRequest presignedUrlRequest =
-                FileRequest.PresignedUrlRequest.builder()
-                        .path("menu_board_response")
-                        .fileType("png")
-                        .build();
-        FileResponse.PresignedUrlResponse preSignedUrl =
-                fileService.getPreSignedUrl(member, presignedUrlRequest);
+            // TODO 이미지 여러 개 보낼 수 있도록 수정
+            FileRequest.PresignedUrlRequest presignedUrlRequest =
+                    FileRequest.PresignedUrlRequest.builder()
+                            .path("menu_board_response")
+                            .fileType("png")
+                            .build();
+            FileResponse.PresignedUrlResponse preSignedUrl =
+                    fileService.getPreSignedUrl(member, presignedUrlRequest);
+
+            // 처리한 3가지 Data를 lambda 밖으로 꺼내기
+            return AiClientRequest.SearchPreparedData.builder()
+                    .imageUrls(imageUrls)
+                    .userAllergies(userAllergies)
+                    .preSignedUrl(preSignedUrl)
+                    .build();
+        });
 
         AiClientRequest.SearchRequest aiSearchRequest = AiClientRequest.SearchRequest.builder()
-                .imageUrl(imageUrls.get(0))
+                .imageUrl(result.getImageUrls().get(0))
                 .menuLang(clientSearchRequest.getMenuLang())
-                .avoid(userAllergies)
-                .presignedUrl(preSignedUrl.getPresignedUrl())
+                .avoid(result.getUserAllergies())
+                .presignedUrl(result.getPreSignedUrl().getPresignedUrl())
                 .lang(member.getLanguage())
                 .build();
         try {
@@ -73,27 +82,29 @@ public class RestaurantService {
             FileRequest.PatchStatusRequest statusRequest = FileRequest.PatchStatusRequest.builder()
                     .fileStatus(FileStatus.UPLOADED)
                     .build();
-            String resultImageUrl = fileService.patchFileStatus(member, preSignedUrl.getFileId(), statusRequest);
 
             SearchHistory searchHistory = SearchHistory.builder()
                     .member(member)
                     .imageIds(clientSearchRequest.getIds())
-                    .resultImageIds(List.of(preSignedUrl.getFileId()))
+                    .resultImageIds(List.of(result.getPreSignedUrl().getFileId()))
                     .searchResult(searchResult)
                     .build();
 
-            searchHistoryRepository.save(searchHistory);
+            String resultImageUrl = transactionTemplate.execute(status -> {
+                searchHistoryRepository.save(searchHistory);
+                return fileService.patchFileStatus(member, result.getPreSignedUrl().getFileId(), statusRequest);
+            });
 
             // RestaurantSearchResult -> RestaurantResponse.SearchResult 변환
             return toSearchResultResponse(searchResult, resultImageUrl);
 
         } catch (feign.RetryableException e) {
             log.error(e.getMessage(), e);
-            handleFileError(preSignedUrl.getFileId(), member);
+            handleFileError(result.getPreSignedUrl().getFileId(), member);
             throw new GeneralException(ErrorStatus.AI_CONNECT_FAIL);
         } catch (feign.FeignException e) {
             log.error(e.getMessage(), e);
-            handleFileError(preSignedUrl.getFileId(), member);
+            handleFileError(result.getPreSignedUrl().getFileId(), member);
             throw new GeneralException(ErrorStatus.AI_SERVER_FAIL);
         }
     }


### PR DESCRIPTION
## 💫 PR 제목
- [Restaurant] 부하 테스트 구현 및 AI 서버 호출 부분을 Transaction에서 분리

---

## 🔧 작업 내용 요약
- Gatling을 사용한 부하 테스트 구현
- 메뉴 검색 시 Transaction을 AI 서버 호출 전, AI 서버 호출 후로 나누고 AI 서버 호출 부분은 제외
- 기피재료 추출을 위한 AI 서버 호출은 Transaction에서 제외
- AI 서버 호출 동시 진행 시 발생하는 에러 수정 (FeignConfig)

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- SearchPreparedData 클래스의 선언이 적절한지 (AI 서버 요청 전 처리한 결과를 lambda 밖으로 빼기 위한 DTO 클래스)
  - lambda 방식으로 구현하던 별도의 함수를 만드는 방식으로 구현하던, lambda 안에서 선언한 변수는 lambda 밖에서 참조할 수 없고, lambda 안에서 lambda 밖의 변수를 수정할 수 없습니다.
  - 함수 형태로 구현하더라도, 함수 안에서 선언한 변수를 함수 밖에서 참조하려면 클래스 변수를 사용해야 하는데, 멀티스레드인 spring 환경에서는 값 전달 목적으로 이를 사용할 수 없습니다.
  - 이때문에 떠오르는 방법이 DTO 클래스로 넘기기나, lambda 밖에서 Object List를 생성해 이를 사용하는 방법 이외에는 없어, 전자를 사용했습니다.
    - `transactionTemplate.execute`에 들어가는 lambda 함수가, return값의 형태로 객체 1개에 한해서 lambda 밖으로 뺄 수 있도록 지원해, 이를 사용했습니다.
  - 지금까지 이런 식으로 서비스 내부 로직에서의 값 전송만을 위한 DTO 클래스를 만든 적이 없어서, 괜찮을지 모르겠습니다.
  - 서비스 내부 로직에서의 값 전송만을 위한 DTO 클래스를 처음 만들다 보니, 이 DTO 클래스는 AiClientRequest 파일에 구현을 진행하였습니다. 이를 다른 곳으로 옮겨 구현해야 할지도 의문입니다.
  - 단 반대로 lambda 밖에서 선언한 변수를 lambda 안에서 참조 및 메서드 호출은 가능합니다.
- Entity를 다루는 서비스는 모든 메서드에 transaction을 적용하고, AI 서버 호출 등 transaction 밖에서 수행해야 하는 일이 있다면 별도의 서비스로 빼거나 controller 단으로 빼는 것이 좋을지
  - `AvoidItemService`의 메서드는 transaction이 적용되는 것(`getMyAvoid`, `updateMyAvoid`)과 그렇지 않은 것(`extractMyAvoid`)이 섞여 있습니다. 도메인은 동일해 이를 하나의 서비스 클래스로 묶었는데, 이를 분리할지에 대한 질문입니다.
- ~~이 작업을 하면서 느낀건데 저희 로직 중 transaction이 반드시 필요한 부분은 별로 없습니다... 이럴 줄 알았으면 그냥 mongodb나 쓸걸~~

---

## 📝 기타 참고 사항
- `transactionTemplate.execute` 사용 방법
  - 기능: 파라미터로 전달한 lambda 함수 내부의 로직을 하나의 transaction 안에서 실행
  - transaction 시작 -> 함수 내부 로직 수행 -> transaction commit
  - 함수 안에서 밖으로 예외가 throw되면 transaction rollback
  - lambda 함수 내부에서 return값을 명시하면, 그 return값이 transactionTemplate.execute 함수(lambda 밖)의 return값이 됨
- `RestaurantService`의 `handleFileError` 함수는 내부에서 transaction을 1회만 사용하므로, 별도의 transaction 설정 미진행
  - 함수 내부에서 호출하는 FileService의 로직에서 transaction이 실행됨
- gatling 사용 방법
  - **spring application을 실행된 상태에서** 프로젝트 루트에서 다음 command 실행
    - linux, macOS: `./gradlew gatlingRun --simulation=com.gdg_team9.SafePlate.restaurant.RestaurantSearchSimulation`
    - windows: `./gradlew.bat gatlingRun --simulation=com.gdg_team9.SafePlate.restaurant.RestaurantSearchSimulation`
  - gatling 사용 전 확인사항
    - `src/gatling/java/com/gdg_team9/SafePlate/restaurant/RestaurantSearchSimulation.java` 코드 내부
      - `loginRequestBody`, `searchRequestBody`가 맞는지 확인
        - 각각 로그인 요청 시 request body, 검색 요청 시 request body
        - DB에 저장된 member 정보 및 file 정보에 맞게 수정 필요
      - 연결된 DB 및 AI 서버 확인 (spring application을 실행하기 전 확인)
        - AI 서버의 역할을 진행하는 별도의 mocking(가짜) 서버를 만든 후 테스트를 권장
          - 식당 검색 API 부하 테스트 시, AI 서버에 무리가 갈 수 있고 외부 AI API에 사용량 제한이 걸릴 수 있음
          - 제가 만들어둔 게 있는데 조금 수정하고 올리겠습니다.
        - 별도의 DB에서 테스트 권장
          - 식당 검색 API 부하 테스트 시, 검색 결과에 맞추어 서버에서 생성하는 이미지(`resultImage`)가 많이 만들어질 수 있음
          - AI mock 서버로 테스트 시, DB에 저장된 이 `resultImage`가 S3에 없는 문제 발생
  - #40 가 **적용되지 않은** 상태에서 gatling 사용을 권장
    - 해당 PR이 사용량 제한 PR인 만큼, 부하 테스트가 정상적으로 이루어지지 않을 수 있음
  - 전송되는 요청의 수를 수정하려면 `RestaurantSearchSimulation` 클래스의 `atOnceUsers(200)` 부분에서 '200' 수정
  - 실행이 완료되면 command line에 `Reports generated, please open the following file: ...`이 나오는데, 이 파일에서 테스트 결과 리포트 확인 가능
  - [gatling 공식 문서](https://docs.gatling.io/)
- 동시에 검색 요청 200개까지 문제 없이 버틸 수 있다는 점을 확인해, **별도의 스레드풀 튜닝은 진행하지 않음** ~~gatling 사용 목적이 스레드풀 튜닝인데 그보다 더 중요한 문제를 잡아버림~~
- `FeignHttpMessageConverters` Bean에 대한 자세한 사항은 [이 Issue](https://github.com/spring-cloud/spring-cloud-openfeign/issues/1307) 참고
- 수정 후 gatling 테스트 결과
  - 리포트 파일을 백업하지 않는 이상 spring 프로젝트를 빌드하면 기존의 리포트가 날아가는 문제가 있어, 나머지 결과는 시간 나는 대로 다시 시행하고 올리겠습니다.
  - 요청 200개
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/c3dd96dd-31dd-41ab-98f1-a2756c5e0dc1" />
(로그인 API 요청 통계)
<img width="1896" height="869" alt="image" src="https://github.com/user-attachments/assets/1a020bdd-33d2-4a35-a508-23396e3e893e" />
(검색 API 요청 통계)